### PR TITLE
Remove News Section

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 gem 'jekyll-paginate'
 gem 'jekyll-sitemap'
+gem "webrick", "~> 1.7"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,7 +55,7 @@
         <nav id="nav">
             <ul>
                 <li><a href="/services" {% if page.url == "/services" %}class="active"{% endif %}>Tjänster</a></li>
-                <li><a href="/news" {% if page.url == "/news/" %}class="active"{% endif %}>Nyheter</a></li>
+                <!-- <li><a href="/news" {% if page.url == "/news/" %}class="active"{% endif %}>Nyheter</a></li> -->
                 <li><a href="/career" {% if page.url == "/career" %}class="active"{% endif %}>Karriär</a></li>
                 <li><a href="/clients" {% if page.url == "/clients" %}class="active"{% endif %}>Kunder</a></li>
                 <li><a href="/about" {% if page.url == "/about" %}class="active"{% endif %}>Om oss</a></li>


### PR DESCRIPTION
Commented (removed) news section due to very old posts. Don´t want to remove it in case we decide to have news on our webpage. But for now it looks bad when the latest post is 2 years old