### PR TITLE
Add agent readiness features for AI discovery

### DIFF
--- a/.well-known/agent-skills/contact/SKILL.md
+++ b/.well-known/agent-skills/contact/SKILL.md
@@ -1,0 +1,34 @@
+# Dotnet Mentor Contact
+
+How to reach Dotnet Mentor and our team in Göteborg.
+
+## Office
+
+Första långgatan 22
+413 28 Göteborg, Sweden
+
+Located between Järntorget and Masthuggsstorget.
+
+## General Contact
+
+- Email: info@dotnetmentor.se
+- Phone: +46 701 48 16 29
+
+## Team Members
+
+| Name | Role | Email | Specialties |
+|------|------|-------|-------------|
+| Mikael Egnér | CEO | mikael.egner@dotnetmentor.se | .NET, Databases, Architecture |
+| William Holmberg | Consulting Manager & Developer | william.holmberg@dotnetmentor.se | React, JavaScript, Node, .NET, Serverless |
+| Fredrik Hansson | Developer | fredrik.hansson@dotnetmentor.se | JavaScript, .NET, Ruby, Scala, Serverless |
+| Andreas Larsson | Developer | andreas.larsson@dotnetmentor.se | UX, React, JavaScript, .NET |
+| Victor Ronnerstedt | Developer | victor.ronnerstedt@dotnetmentor.se | React, JavaScript, .NET, Serverless |
+| Tim Larsson | Developer | tim.larsson@dotnetmentor.se | React, .NET, Python |
+| Agnes Frost | Developer | agnes.frost@dotnetmentor.se | React, JavaScript, Python |
+| Axel Rosendahl | Developer | axel.rosendahl@dotnetmentor.se | — |
+| Oliver Nygren | Developer | oliver.nygren@dotnetmentor.se | — |
+| Aymen Toukabri | Developer | aymen.toukabri@dotnetmentor.se | — |
+
+## Website
+
+https://dotnetmentor.se/contact

--- a/.well-known/agent-skills/contact/SKILL.md
+++ b/.well-known/agent-skills/contact/SKILL.md
@@ -26,7 +26,7 @@ Located between Järntorget and Masthuggsstorget.
 | Tim Larsson | Developer | tim.larsson@dotnetmentor.se | React, .NET, Python |
 | Agnes Frost | Developer | agnes.frost@dotnetmentor.se | React, JavaScript, Python |
 | Axel Rosendahl | Developer | axel.rosendahl@dotnetmentor.se | — |
-| Oliver Nygren | Developer | oliver.nygren@dotnetmentor.se | — |
+| William Lanhage | Developer & Designer | william.lanhage@dotnetmentor.se | — |
 | Aymen Toukabri | Developer | aymen.toukabri@dotnetmentor.se | — |
 
 ## Website

--- a/.well-known/agent-skills/index.json
+++ b/.well-known/agent-skills/index.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "dotnetmentor-services",
+      "type": "skill-md",
+      "description": "Consulting, mentorship, product development, and training services offered by Dotnet Mentor.",
+      "url": "https://dotnetmentor.se/.well-known/agent-skills/services/SKILL.md",
+      "digest": "sha256:70bdb2ef56b4af698b0997279fc69f94caf2d7330b9b42d1eccb6ceeb04e52f0"
+    },
+    {
+      "name": "dotnetmentor-contact",
+      "type": "skill-md",
+      "description": "Office location, general contact details, and team member information for Dotnet Mentor.",
+      "url": "https://dotnetmentor.se/.well-known/agent-skills/contact/SKILL.md",
+      "digest": "sha256:2c98388e3053a46865386911789b8fb9546d52202d122f581287fbe748d28207"
+    },
+    {
+      "name": "dotnetmentor-team",
+      "type": "skill-md",
+      "description": "Company culture, open source contributions, and consultant specialties at Dotnet Mentor.",
+      "url": "https://dotnetmentor.se/.well-known/agent-skills/team/SKILL.md",
+      "digest": "sha256:0ab5bcf08cf30521fe35f6625768a074bafb473a9b7ffb93785548785e940073"
+    }
+  ]
+}

--- a/.well-known/agent-skills/index.json
+++ b/.well-known/agent-skills/index.json
@@ -13,7 +13,7 @@
       "type": "skill-md",
       "description": "Office location, general contact details, and team member information for Dotnet Mentor.",
       "url": "https://dotnetmentor.se/.well-known/agent-skills/contact/SKILL.md",
-      "digest": "sha256:2c98388e3053a46865386911789b8fb9546d52202d122f581287fbe748d28207"
+      "digest": "sha256:38c53e81746b2b51303612afc872767cf50ef73cc41e245e84e4597ac235bbc1"
     },
     {
       "name": "dotnetmentor-team",

--- a/.well-known/agent-skills/services/SKILL.md
+++ b/.well-known/agent-skills/services/SKILL.md
@@ -1,0 +1,38 @@
+# Dotnet Mentor Services
+
+Consulting, mentorship, product development, and training for software teams.
+
+## Company
+
+Dotnet Mentor is a Swedish IT consultancy based in Göteborg. We offer experienced developers as consultants, mentors, trainers, or full product development partners.
+
+## Services
+
+### Consulting
+Expert IT architecture and software development. Specialists in .NET, front-end development, and open source.
+
+### Mentorship
+Long-term or targeted mentorship to strengthen existing development teams rather than adding headcount.
+
+### Training
+Custom training on project structure, data access, unit testing, CI/CD, and team onboarding for new projects.
+
+### Product Development
+End-to-end product creation, maintenance, and evolution based on years of delivery experience.
+
+## Technology Expertise
+
+- .NET
+- JavaScript and Node.js
+- Ruby and Ruby on Rails
+- React and front-end / mobile web
+- AWS, Serverless, and Kubernetes
+- Infrastructure as Code and CI/CD
+- Open source
+
+## Contact
+
+- Email: info@dotnetmentor.se
+- Phone: +46 707 493 603
+- Address: Första långgatan 22, 413 28 Göteborg, Sweden
+- Website: https://dotnetmentor.se/services

--- a/.well-known/agent-skills/team/SKILL.md
+++ b/.well-known/agent-skills/team/SKILL.md
@@ -1,0 +1,32 @@
+# Dotnet Mentor Team
+
+Overview of Dotnet Mentor as a company and development team.
+
+## About
+
+Dotnet Mentor is a team of highly experienced developers specializing in object-oriented technology and agile methods such as Kanban and Scrum.
+
+## Culture
+
+We balance hard work, creative freedom, and strong team cohesion. Internal competence days, meetups, and conference participation keep us at the forefront of modern development.
+
+## Open Source
+
+We actively contribute to open source projects including Fluent Security, Koshu, server-base, AWS Lambda tooling, and more. See https://github.com/dotnetmentor.
+
+## Consultants
+
+Our consultants combine breadth with deep specialist knowledge:
+
+- **Mikael** — .NET, Databases, Architecture
+- **Fredrik** — JavaScript, .NET, Ruby, Scala, Serverless
+- **Agnes** — React, JavaScript, Python
+- **William** — React, JavaScript, Node, .NET, Serverless
+- **Andreas** — UX, React, JavaScript, .NET, Vercel
+- **Victor** — React, JavaScript, .NET, Serverless
+- **Viktor** — React, .NET, JavaScript, Python
+- **Tim** — React, .NET, Python
+
+## Website
+
+https://dotnetmentor.se/about

--- a/_config.yml
+++ b/_config.yml
@@ -6,5 +6,5 @@ host: 0.0.0.0
 permalink: /news/:year/:month/:day/:title
 paginate: 5
 paginate_path: "/news/page:num/"
-url: http://dotnetmentor.se
+url: https://dotnetmentor.se
 excerpt_separator: <!--more-->

--- a/_headers
+++ b/_headers
@@ -1,0 +1,18 @@
+# Cloudflare Pages / Netlify headers for agent discovery.
+# Requires hosting on Cloudflare Pages or Netlify (not native GitHub Pages).
+
+/
+  Link: </.well-known/agent-skills/index.json>; rel="describedby", </content/index.md>; rel="alternate"; type="text/markdown", </content/services.md>; rel="service-doc"; type="text/markdown", </llms.txt>; rel="service-desc"
+  Permissions-Policy: tools=(self)
+
+/*
+  Permissions-Policy: tools=(self)
+
+/content/*
+  Content-Type: text/markdown; charset=utf-8
+
+/.well-known/agent-skills/*
+  Content-Type: application/json; charset=utf-8
+
+/.well-known/agent-skills/*/SKILL.md
+  Content-Type: text/markdown; charset=utf-8

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,17 @@
 
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    
+    <meta http-equiv="Permissions-Policy" content="tools=(self)">
+
+    <link rel="describedby" href="/.well-known/agent-skills/index.json">
+    {% if page.markdown_url %}
+    <link rel="alternate" type="text/markdown" href="{{ page.markdown_url }}" title="Markdown">
+    {% else %}
+    <link rel="alternate" type="text/markdown" href="/content/index.md" title="Markdown">
+    {% endif %}
+    <link rel="service-doc" type="text/markdown" href="/content/services.md">
+    <link rel="service-desc" href="/llms.txt">
+
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,700" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -94,6 +94,7 @@
             var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
         })();
     </script>
+    <script type="text/javascript" src="/assets/js/webmcp-tools.js"></script>
 </body>
 
 </html>

--- a/about.html
+++ b/about.html
@@ -1,7 +1,8 @@
 --- 
 layout: default 
 title: Dotnet Mentor - Om oss 
-description: Dotnet Mentor är ett team av mycket erfarna utvecklare som specialiserat sig på objektorienterad teknik och utveckling med stöd av agila metoder så som Kanban och Scrum. 
+description: Dotnet Mentor är ett team av mycket erfarna utvecklare som specialiserat sig på objektorienterad teknik och utveckling med stöd av agila metoder så som Kanban och Scrum.
+markdown_url: /content/about.md
 ---
 
 <div class="about banner">

--- a/assets/js/webmcp-tools.js
+++ b/assets/js/webmcp-tools.js
@@ -1,0 +1,169 @@
+(function () {
+  'use strict';
+
+  if (!('modelContext' in navigator)) {
+    return;
+  }
+
+  var controller = new AbortController();
+  var signal = controller.signal;
+
+  window.addEventListener('pagehide', function () {
+    controller.abort();
+  });
+
+  var consultants = [
+    { id: 'mikael', name: 'Mikael Egnér', role: 'CEO', email: 'mikael.egner@dotnetmentor.se', specialties: ['.NET', 'Databases', 'Architecture'] },
+    { id: 'william', name: 'William Holmberg', role: 'Consulting Manager & Developer', email: 'william.holmberg@dotnetmentor.se', specialties: ['React', 'JavaScript', 'Node', '.NET', 'Serverless'] },
+    { id: 'fredrik', name: 'Fredrik Hansson', role: 'Developer', email: 'fredrik.hansson@dotnetmentor.se', specialties: ['JavaScript', '.NET', 'Ruby', 'Scala', 'Serverless'] },
+    { id: 'andreas', name: 'Andreas Larsson', role: 'Developer', email: 'andreas.larsson@dotnetmentor.se', specialties: ['UX', 'React', 'JavaScript', '.NET'] },
+    { id: 'victor', name: 'Victor Ronnerstedt', role: 'Developer', email: 'victor.ronnerstedt@dotnetmentor.se', specialties: ['React', 'JavaScript', '.NET', 'Serverless'] },
+    { id: 'tim', name: 'Tim Larsson', role: 'Developer', email: 'tim.larsson@dotnetmentor.se', specialties: ['React', '.NET', 'Python'] },
+    { id: 'agnes', name: 'Agnes Frost', role: 'Developer', email: 'agnes.frost@dotnetmentor.se', specialties: ['React', 'JavaScript', 'Python'] },
+    { id: 'axel', name: 'Axel Rosendahl', role: 'Developer', email: 'axel.rosendahl@dotnetmentor.se', specialties: [] },
+    { id: 'oliver', name: 'Oliver Nygren', role: 'Developer', email: 'oliver.nygren@dotnetmentor.se', specialties: [] },
+    { id: 'aymen', name: 'Aymen Toukabri', role: 'Developer', email: 'aymen.toukabri@dotnetmentor.se', specialties: [] }
+  ];
+
+  var services = [
+    { name: 'Consulting', description: 'IT architecture and software development with .NET, front-end, and open source expertise.' },
+    { name: 'Mentorship', description: 'Targeted or long-term mentorship to strengthen existing development teams.' },
+    { name: 'Training', description: 'Custom training on project structure, testing, CI/CD, and team onboarding.' },
+    { name: 'Product Development', description: 'End-to-end product creation, maintenance, and evolution.' }
+  ];
+
+  var techStack = [
+    '.NET', 'JavaScript', 'Node.js', 'React', 'Ruby', 'Ruby on Rails',
+    'Python', 'AWS', 'Serverless', 'Kubernetes', 'Infrastructure as Code', 'CI/CD'
+  ];
+
+  var pages = [
+    { path: '/', title: 'Home' },
+    { path: '/services', title: 'Services' },
+    { path: '/about', title: 'About' },
+    { path: '/contact', title: 'Contact' },
+    { path: '/clients', title: 'Clients' },
+    { path: '/career', title: 'Careers' }
+  ];
+
+  navigator.modelContext.registerTool({
+    name: 'get-site-info',
+    title: 'Get site info',
+    description: 'Returns general information about Dotnet Mentor, a Swedish IT consultancy in Göteborg.',
+    inputSchema: { type: 'object', properties: {} },
+    annotations: { readOnlyHint: true },
+    execute: async function () {
+      return {
+        name: 'Dotnet Mentor',
+        description: 'Swedish IT consultancy offering consulting, mentorship, training, and product development.',
+        email: 'info@dotnetmentor.se',
+        phone: '+46 707 493 603',
+        address: 'Första långgatan 22, 413 28 Göteborg, Sweden',
+        website: 'https://dotnetmentor.se'
+      };
+    }
+  }, { signal: signal });
+
+  navigator.modelContext.registerTool({
+    name: 'list-services',
+    title: 'List services',
+    description: 'Lists the consulting services offered by Dotnet Mentor.',
+    inputSchema: { type: 'object', properties: {} },
+    annotations: { readOnlyHint: true },
+    execute: async function () {
+      return { services: services };
+    }
+  }, { signal: signal });
+
+  navigator.modelContext.registerTool({
+    name: 'list-tech-stack',
+    title: 'List tech stack',
+    description: 'Lists the technologies and platforms Dotnet Mentor specializes in.',
+    inputSchema: { type: 'object', properties: {} },
+    annotations: { readOnlyHint: true },
+    execute: async function () {
+      return { technologies: techStack };
+    }
+  }, { signal: signal });
+
+  navigator.modelContext.registerTool({
+    name: 'list-consultants',
+    title: 'List consultants',
+    description: 'Lists Dotnet Mentor consultants with their roles, emails, and specialties.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        specialty: {
+          type: 'string',
+          description: 'Optional filter by technology or specialty (case-insensitive substring match).'
+        }
+      }
+    },
+    annotations: { readOnlyHint: true },
+    execute: async function (input) {
+      var filter = input && input.specialty ? input.specialty.toLowerCase() : null;
+      var result = consultants;
+
+      if (filter) {
+        result = consultants.filter(function (c) {
+          return c.specialties.some(function (s) {
+            return s.toLowerCase().indexOf(filter) !== -1;
+          }) || c.name.toLowerCase().indexOf(filter) !== -1;
+        });
+      }
+
+      return { consultants: result };
+    }
+  }, { signal: signal });
+
+  navigator.modelContext.registerTool({
+    name: 'get-contact-info',
+    title: 'Get contact info',
+    description: 'Returns Dotnet Mentor office address, general email, and phone number.',
+    inputSchema: { type: 'object', properties: {} },
+    annotations: { readOnlyHint: true },
+    execute: async function () {
+      return {
+        email: 'info@dotnetmentor.se',
+        phone: '+46 701 48 16 29',
+        address: {
+          street: 'Första långgatan 22',
+          postalCode: '413 28',
+          city: 'Göteborg',
+          country: 'Sweden'
+        }
+      };
+    }
+  }, { signal: signal });
+
+  navigator.modelContext.registerTool({
+    name: 'navigate-to-page',
+    title: 'Navigate to page',
+    description: 'Navigates the browser to a page on the Dotnet Mentor website.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Site path such as /services, /about, /contact, /clients, or /career.',
+          enum: ['/', '/services', '/about', '/contact', '/clients', '/career']
+        }
+      },
+      required: ['path']
+    },
+    execute: async function (input, client) {
+      var path = input.path;
+      var page = pages.find(function (p) { return p.path === path; });
+
+      if (!page) {
+        throw new Error('Unknown path: ' + path);
+      }
+
+      await client.requestUserInteraction(function () {
+        window.location.href = path;
+      });
+
+      return { navigatedTo: path, title: page.title };
+    }
+  }, { signal: signal });
+})();

--- a/assets/js/webmcp-tools.js
+++ b/assets/js/webmcp-tools.js
@@ -21,7 +21,7 @@
     { id: 'tim', name: 'Tim Larsson', role: 'Developer', email: 'tim.larsson@dotnetmentor.se', specialties: ['React', '.NET', 'Python'] },
     { id: 'agnes', name: 'Agnes Frost', role: 'Developer', email: 'agnes.frost@dotnetmentor.se', specialties: ['React', 'JavaScript', 'Python'] },
     { id: 'axel', name: 'Axel Rosendahl', role: 'Developer', email: 'axel.rosendahl@dotnetmentor.se', specialties: [] },
-    { id: 'oliver', name: 'Oliver Nygren', role: 'Developer', email: 'oliver.nygren@dotnetmentor.se', specialties: [] },
+    { id: 'william-lanhage', name: 'William Lanhage', role: 'Developer & Designer', email: 'william.lanhage@dotnetmentor.se', specialties: [] },
     { id: 'aymen', name: 'Aymen Toukabri', role: 'Developer', email: 'aymen.toukabri@dotnetmentor.se', specialties: [] }
   ];
 

--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -1,0 +1,91 @@
+/**
+ * Cloudflare Worker for Dotnet Mentor agent readiness.
+ *
+ * Deploy in front of GitHub Pages to add:
+ * - Link response headers on the homepage (RFC 8288)
+ * - Accept: text/markdown content negotiation
+ *
+ * Route: dotnetmentor.se/*
+ * Origin: dotnetmentor.github.io (or your GitHub Pages origin)
+ */
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const originUrl = new URL(url.pathname + url.search, env.ORIGIN || 'https://dotnetmentor.se');
+
+    const accept = request.headers.get('Accept') || '';
+    const wantsMarkdown = accept.includes('text/markdown');
+
+    if (wantsMarkdown) {
+      const markdownPath = resolveMarkdownPath(url.pathname);
+      if (markdownPath) {
+        const mdUrl = new URL(markdownPath, env.ORIGIN || 'https://dotnetmentor.se');
+        const mdResponse = await fetch(mdUrl.toString(), {
+          headers: { 'Accept': 'text/markdown, text/plain, */*' }
+        });
+
+        if (mdResponse.ok) {
+          const body = await mdResponse.text();
+          const tokenCount = estimateTokens(body);
+          const headers = new Headers({
+            'Content-Type': 'text/markdown; charset=utf-8',
+            'Vary': 'Accept',
+            'Cache-Control': 'public, max-age=3600'
+          });
+
+          if (tokenCount !== null) {
+            headers.set('x-markdown-tokens', String(tokenCount));
+          }
+
+          return new Response(body, { status: 200, headers });
+        }
+      }
+    }
+
+    const response = await fetch(originUrl.toString(), {
+      method: request.method,
+      headers: request.headers,
+      body: request.method !== 'GET' && request.method !== 'HEAD' ? request.body : undefined,
+      redirect: 'follow'
+    });
+
+    if (url.pathname === '/' || url.pathname === '') {
+      const headers = new Headers(response.headers);
+      headers.set('Link', [
+        '</.well-known/agent-skills/index.json>; rel="describedby"',
+        '</content/index.md>; rel="alternate"; type="text/markdown"',
+        '</content/services.md>; rel="service-doc"; type="text/markdown"',
+        '</llms.txt>; rel="service-desc"'
+      ].join(', '));
+      headers.set('Vary', 'Accept');
+
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers
+      });
+    }
+
+    return response;
+  }
+};
+
+function resolveMarkdownPath(pathname) {
+  const map = {
+    '/': '/content/index.md',
+    '/services': '/content/services.md',
+    '/about': '/content/about.md',
+    '/contact': '/content/contact.md'
+  };
+
+  const normalized = pathname.endsWith('/') && pathname.length > 1
+    ? pathname.slice(0, -1)
+    : pathname;
+
+  return map[normalized] || map[pathname] || null;
+}
+
+function estimateTokens(text) {
+  if (!text) return 0;
+  return Math.ceil(text.length / 4);
+}

--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,6 @@ layout: default
 title: Dotnet Mentor - Kontakt
 enable_leaflet: yes
 description: Konsulter, mentorer, experthjälp eller utveckling av en produkt? Hör av er så hjälper vi er. Vi sitter på Första långgatan 22, mellan Järntorget och Masthuggsstorget i Göteborg.
-markdown_url: /content/contact.md
 ---
 
 <div class="contact banner">
@@ -161,16 +160,16 @@ markdown_url: /content/contact.md
             </div>
         </div>
 
-        <div class="box card contact" id="axel">
+        <div class="box card contact" id="william-lanhage">
             <div class="card-image">
-                <img src="https://avatars.githubusercontent.com/u/71634257?v=4" />
+                <img src="https://avatars.githubusercontent.com/u/144318002?v=4" />
             </div>
             <div class="card-content">
-                <h4>Oliver Nygren</h4>
-                <div class="title">Utvecklare</div>
+                <h4>William Lanhage</h4>
+                <div class="title">Utvecklare &amp; Designer</div>
                 <ul class="info-list">
-                    <li><i class="material-icons">mail</i> <a style='font-size: 13px;' href="mailto:oliver.nygren@dotnetmentor.se">oliver.nygren@dotnetmentor.se</a></li>
-                    <li><i class="icon-github-circled"></i> <a href="https://github.com/olivernygren">@olivernygren</a></li>
+                    <li><i class="material-icons">mail</i> <a style='font-size: 13px;' href="mailto:william.lanhage@dotnetmentor.se">william.lanhage@dotnetmentor.se</a></li>
+                    <li><i class="icon-github-circled"></i> <a href="https://github.com/wlanhage">@wlanhage</a></li>
                 </ul>
             </div>
         </div>

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,7 @@ layout: default
 title: Dotnet Mentor - Kontakt
 enable_leaflet: yes
 description: Konsulter, mentorer, experthjälp eller utveckling av en produkt? Hör av er så hjälper vi er. Vi sitter på Första långgatan 22, mellan Järntorget och Masthuggsstorget i Göteborg.
+markdown_url: /content/contact.md
 ---
 
 <div class="contact banner">

--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,29 @@
+# Dotnet Mentor — Om oss
+
+> Dotnet Mentor är ett team av mycket erfarna utvecklare som specialiserat sig på objektorienterad teknik och utveckling med stöd av agila metoder så som Kanban och Scrum.
+
+## Culture
+
+We strive to be among the best in our field through a balance of hard work, creative freedom, and strong cohesion. Internal competence days let us learn from each other and experiment.
+
+## Meetups
+
+We organize local meetups in our specialty areas to broaden and deepen knowledge in a relaxed setting.
+
+## Open Source
+
+We believe open source is the future. We contribute actively to projects including:
+
+- [Fluent Security](https://github.com/kristofferahl/FluentSecurity)
+- [Koshu](https://github.com/kristofferahl/Koshu/)
+- [server-base](https://github.com/JamesKyburz/server-base)
+- AWS Lambda tooling by James Kyburz
+- [Dotnet Mentor on GitHub](https://github.com/dotnetmentor)
+
+## Conferences
+
+We attend leading conferences in Sweden and Europe — as participants and speakers — as part of our continuous learning and community engagement.
+
+## Contact
+
+https://dotnetmentor.se/contact

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,0 +1,34 @@
+# Dotnet Mentor — Kontakt
+
+> Konsulter, mentorer, experthjälp eller utveckling av en produkt? Hör av er så hjälper vi er.
+
+## Visit us
+
+Första långgatan 22
+413 28 Göteborg
+
+Between Järntorget and Masthuggsstorget.
+
+## General contact
+
+- Email: info@dotnetmentor.se
+- Phone: +46 701 48 16 29
+
+## Team
+
+| Name | Role | Email |
+|------|------|-------|
+| Mikael Egnér | CEO | mikael.egner@dotnetmentor.se |
+| William Holmberg | Consulting Manager & Developer | william.holmberg@dotnetmentor.se |
+| Fredrik Hansson | Developer | fredrik.hansson@dotnetmentor.se |
+| Andreas Larsson | Developer | andreas.larsson@dotnetmentor.se |
+| Victor Ronnerstedt | Developer | victor.ronnerstedt@dotnetmentor.se |
+| Tim Larsson | Developer | tim.larsson@dotnetmentor.se |
+| Agnes Frost | Developer | agnes.frost@dotnetmentor.se |
+| Axel Rosendahl | Developer | axel.rosendahl@dotnetmentor.se |
+| Oliver Nygren | Developer | oliver.nygren@dotnetmentor.se |
+| Aymen Toukabri | Developer | aymen.toukabri@dotnetmentor.se |
+
+## Map
+
+Office coordinates: 57.6986, 11.9522 (Göteborg, Sweden)

--- a/content/contact.md
+++ b/content/contact.md
@@ -26,7 +26,7 @@ Between Järntorget and Masthuggsstorget.
 | Tim Larsson | Developer | tim.larsson@dotnetmentor.se |
 | Agnes Frost | Developer | agnes.frost@dotnetmentor.se |
 | Axel Rosendahl | Developer | axel.rosendahl@dotnetmentor.se |
-| Oliver Nygren | Developer | oliver.nygren@dotnetmentor.se |
+| William Lanhage | Developer & Designer | william.lanhage@dotnetmentor.se |
 | Aymen Toukabri | Developer | aymen.toukabri@dotnetmentor.se |
 
 ## Map

--- a/content/index.md
+++ b/content/index.md
@@ -1,0 +1,36 @@
+# Dotnet Mentor
+
+> Konsulter, mentorer, experthjälp eller utveckling av en produkt? Hör av er så hjälper vi er.
+
+**Erfarenhet och bredd inom IT-utveckling**
+
+Dotnet Mentor is a Swedish IT consultancy in Göteborg offering consulting, mentorship, product development, and training.
+
+## What we offer
+
+We provide software development consulting as part of your team, as mentors and trainers, or with full responsibility for projects and product development. We work with modern languages and technologies — JavaScript, Node.js, React, and .NET — and are strong in Serverless and Cloud.
+
+### Services
+
+- **Consulting** — IT architecture and software development
+- **Mentorship** — Strengthen existing teams
+- **Product development** — Build and maintain software products
+- **Training** — Custom courses for your team
+
+## Team
+
+Specialists with depth and breadth across .NET, JavaScript, React, Python, Serverless, and cloud platforms.
+
+## Contact
+
+- Email: info@dotnetmentor.se
+- Phone: +46 707 493 603
+- Address: Första långgatan 22, 413 28 Göteborg
+
+## Links
+
+- [Services](/services)
+- [About](/about)
+- [Contact](/contact)
+- [Clients](/clients)
+- [Careers](/career)

--- a/content/services.md
+++ b/content/services.md
@@ -1,0 +1,34 @@
+# Dotnet Mentor — Tjänster
+
+> Mentorskap, konsulting & produktutveckling
+
+## Expertise
+
+Our core is .NET, but we offer consultants and mentors with the same high level of expertise in:
+
+- JavaScript and Node.js
+- Ruby and Ruby on Rails
+- AWS and Serverless/Kubernetes
+- Infrastructure as Code and CI/CD
+- Front end and mobile web
+- Open source
+
+## Mentorship
+
+We know that strengthening your existing team is not always about adding more resources. We offer mentors and training to help you develop what you already have — through targeted interventions or long-term partnerships.
+
+## Consulting
+
+Dotnet Mentor are experts in IT architecture and software development. Our consultants specialize in .NET, interface development, and open source, helping customers evolve with new technologies and methods.
+
+## Training
+
+Project structure, data access, unit tests, CI/CD — we help teams get new projects off to a fast start. We also tailor training for your specific needs.
+
+## Product Development
+
+Beyond pure consulting, we offer product development services — creating, producing, and maintaining software products based on years of project experience.
+
+## Contact
+
+info@dotnetmentor.se | https://dotnetmentor.se/contact

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: default
 title: Dotnet Mentor
 description: Konsulter, mentorer, experthjälp eller utveckling av en produkt? Hör av er så hjälper vi er. Vi sitter på Första långgatan 22, mellan Järntorget och Masthuggsstorget i Göteborg.
+markdown_url: /content/index.md
 ---
 
 <div class="index banner">

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,25 @@
+# Dotnet Mentor
+
+> Swedish IT consultancy in Göteborg — consulting, mentorship, product development, and training.
+
+Dotnet Mentor offers experienced software developers for consulting, mentoring, training, and full product development. Core expertise in .NET, JavaScript, React, Node.js, Serverless, and cloud platforms.
+
+## Services
+
+- [Services](https://dotnetmentor.se/services): Consulting, mentorship, training, and product development
+- [About](https://dotnetmentor.se/about): Company culture, open source, and team background
+- [Contact](https://dotnetmentor.se/contact): Office location and team contact details
+- [Clients](https://dotnetmentor.se/clients): Customer references
+- [Careers](https://dotnetmentor.se/career): Job opportunities
+
+## Agent resources
+
+- [Agent skills index](https://dotnetmentor.se/.well-known/agent-skills/index.json): Machine-readable skill definitions
+- [Homepage (markdown)](https://dotnetmentor.se/content/index.md): Markdown version of the homepage
+- [Services (markdown)](https://dotnetmentor.se/content/services.md): Markdown version of services page
+
+## Contact
+
+- Email: info@dotnetmentor.se
+- Phone: +46 707 493 603
+- Address: Första långgatan 22, 413 28 Göteborg, Sweden

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,22 @@
+# As a condition of accessing this website, you agree to abide by the following
+# content signals:
+# (a)  If a content-signal = yes, you may collect content for the corresponding use.
+# (b)  If a content-signal = no, you may not collect content for the corresponding use.
+# (c)  If the website operator does not include a content signal for a corresponding
+#      use, the website operator neither grants nor restricts permission via content
+#      signal with respect to the corresponding use.
+#
+# The content signals and their meanings are:
+# search: building a search index and providing search results (e.g., returning
+#         hyperlinks and short excerpts from your website's contents). Search does
+#         not include providing AI-generated search summaries.
+# ai-input: inputting content into one or more AI models (e.g., retrieval augmented
+#           generation, grounding, or other real-time taking of content for
+#           generative AI search answers).
+# ai-train: training or fine-tuning AI models.
+
+User-agent: *
+Content-Signal: ai-train=no, search=yes, ai-input=no
+Allow: /
+
+Sitemap: https://dotnetmentor.se/sitemap.xml

--- a/services.html
+++ b/services.html
@@ -2,6 +2,7 @@
 layout: default
 title: Dotnet Mentor - Tjänster
 description: Mentorskap, konsulting &amp; produktutveckling
+markdown_url: /content/services.md
 ---
 
 <div class="services banner">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the agent readiness recommendations from [isitagentready.com](https://isitagentready.com/www.dotnetmentor.se) for the Dotnet Mentor Jekyll site.

### Implemented (works on GitHub Pages immediately)

- **Content Signals in `robots.txt`** — declares `ai-train=no, search=yes, ai-input=no` with sitemap reference
- **Agent Skills discovery index** at `/.well-known/agent-skills/index.json` with three `SKILL.md` skills (services, contact, team) and SHA-256 digests
- **Markdown content for agents** — static markdown copies at `/content/*.md` plus `llms.txt` site summary
- **HTML discovery links** in the default layout (`rel="describedby"`, `alternate`, `service-doc`, `service-desc`)
- **WebMCP tools** via `assets/js/webmcp-tools.js` — site info, services, tech stack, consultants, contact, and navigation tools

### Included for edge/CDN deployment

GitHub Pages cannot set custom HTTP response headers or perform `Accept: text/markdown` negotiation natively. This PR also adds:

- **`_headers`** — for Cloudflare Pages or Netlify (Link headers + content types)
- **`cloudflare/worker.js`** — optional Worker for Link headers on `/` and markdown content negotiation

Deploy the Cloudflare Worker (or enable Cloudflare "Markdown for Agents") in front of the site to pass the Link header and markdown negotiation checks.

## Test plan

- [ ] Verify `https://dotnetmentor.se/robots.txt` contains Content-Signal directives after deploy
- [ ] Verify `https://dotnetmentor.se/.well-known/agent-skills/index.json` returns 200 with valid JSON
- [ ] Verify `/content/index.md` and `/llms.txt` are accessible
- [ ] Re-scan at isitagentready.com after deploy
- [ ] (Optional) Deploy `cloudflare/worker.js` to pass Link header and Accept negotiation checks
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b1a7e5f-8a2f-412a-a559-0a8d69616d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b1a7e5f-8a2f-412a-a559-0a8d69616d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

