### PR TITLE
Add AGENTS.md with development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Jekyll (Ruby) static site for a Swedish IT consulting company (dotnetmentor.se). It uses GitHub Pages with the `github-pages` gem.
+
+### Running the dev server
+
+```
+bundle exec jekyll serve
+```
+
+Site is served at `http://localhost:4000` (binds to `0.0.0.0` per `_config.yml`).
+
+### Build
+
+```
+bundle exec jekyll build
+```
+
+Output goes to `_site/`.
+
+### Known warnings (safe to ignore)
+
+- **Deprecation**: `'gems'` config option renamed to `'plugins'` — cosmetic warning, does not affect functionality.
+- **Liquid Warning** on `index.html` line 146 — pre-existing syntax quirk, site renders correctly.
+- **GitHub Metadata** warning about `site.name` vs `site.title` — informational only.
+- **Sass end-of-life** notice — the `github-pages` gem still bundles Ruby Sass; no action needed.
+
+### Notes
+
+- There is no linter or test suite configured in this repository.
+- The `cv-generator/` subdirectory is a separate sub-project with its own `index.md`; it is built as part of the main Jekyll site.
+- Ruby 3.2+ requires the `webrick` gem (already in `Gemfile`).
+- Gems are installed system-wide with `sudo bundle install` (or configure a local gem path if preferred).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents working in this repository.

Includes:
- How to run the Jekyll dev server (`bundle exec jekyll serve`)
- How to build the site (`bundle exec jekyll build`)
- Known safe-to-ignore warnings (deprecation notices, Liquid syntax warning, etc.)
- Notes about the CV generator sub-project and Ruby 3.2+ webrick requirement

This file helps future cloud agents quickly understand how to set up and run the development environment without needing to re-discover these details each time.

## Demo

[demo_jekyll_site_navigation.mp4](https://cursor.com/agents/bc-7d29fd89-4a09-4481-b8ff-3fd08bbf0912/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_jekyll_site_navigation.mp4)

Jekyll site running at localhost:4000, navigating through homepage, services, and news pages.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d29fd89-4a09-4481-b8ff-3fd08bbf0912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d29fd89-4a09-4481-b8ff-3fd08bbf0912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

